### PR TITLE
change fee calculation algo

### DIFF
--- a/src/Lykke.Service.LiteCoin.API.Services/Broadcast/BroadcastService.cs
+++ b/src/Lykke.Service.LiteCoin.API.Services/Broadcast/BroadcastService.cs
@@ -49,7 +49,7 @@ namespace Lykke.Service.LiteCoin.API.Services.Broadcast
 
             if (await _operationEventRepository.Exist(operationId, OperationEventType.Broadcasted))
             {
-                throw new BusinessException("Operation not found", ErrorCode.OperationNotFound);
+                throw new BusinessException("Transaction already brodcasted", ErrorCode.TransactionAlreadyBroadcasted);
             }
 
             await _transactionBlobStorage.AddOrReplaceTransaction(operationId,TransactionBlobType.BeforeBroadcast, tx.ToHex());

--- a/src/Lykke.Service.LiteCoin.API.Services/Transactions/TransactionBuilderService.cs
+++ b/src/Lykke.Service.LiteCoin.API.Services/Transactions/TransactionBuilderService.cs
@@ -74,17 +74,11 @@ namespace Lykke.Service.LiteCoin.API.Services.Transactions
             var sendAmount = Money.Zero;
             var cnt = GetCoinsCount(amount, orderedCoins, ref sendAmount);
 
-            builder.AddCoins(orderedCoins.Take(cnt));
-
+            builder.AddCoins(orderedCoins.Take(cnt))
+                .Send(destination, amount)
+                .SetChange(changeDestination);
+            
             var fee = await _feeService.CalcFeeForTransaction(builder);
-
-            if (fee >= amount)
-            {
-                throw new BusinessException(
-                    $"The sum of total applicable outputs is less than the required fee: {fee} satoshis.",
-                    ErrorCode.BalanceIsLessThanFee);
-            }
-
 
             if (!includeFee && sendAmount < amount + fee)
             {
@@ -92,26 +86,35 @@ namespace Lykke.Service.LiteCoin.API.Services.Transactions
                     .OrderBy(o => o.Amount)
                     .ToList();
 
-                var feeCoinsCnt = GetCoinsCount(amount + fee, orderedFeeCoins, ref sendAmount);
-
+                var feeCoinsCnt = GetCoinsCount(fee, orderedFeeCoins, ref sendAmount);
                 builder.AddCoins(orderedFeeCoins.Take(feeCoinsCnt));
             }
 
-            builder.Send(destination, amount);
-
+            if (fee >= amount)
+            {
+                throw new BusinessException(
+                    $"The sum of total applicable outputs is less than the required fee: {fee} satoshis.",
+                    ErrorCode.BalanceIsLessThanFee);
+            }
+            
             if (includeFee)
             {
                 builder.SubtractFees();
                 amount = amount - fee;
             }
 
-            builder.SetChange(changeDestination);
-
-            builder.SendFees(fee);
-            builder.BuildTransaction(false);
+            if (sendAmount < amount + fee)
+            {
+                throw new BusinessException(
+                    $"The sum of total applicable outputs is less than the required: {amount.Satoshi} satoshis.",
+                    ErrorCode.NotEnoughFundsAvailable);
+            }
             
+            builder.SendFees(fee);
 
-            return BuildedTransaction.Create(builder.BuildTransaction(false), fee, amount);
+            var tx = builder.BuildTransaction(false);
+
+            return BuildedTransaction.Create(tx, fee, amount);
         }
 
         private static int GetCoinsCount(Money amount, List<Coin> orderedCoins, ref Money sendAmount)
@@ -121,13 +124,6 @@ namespace Lykke.Service.LiteCoin.API.Services.Transactions
             {
                 sendAmount += orderedCoins[cnt].TxOut.Value;
                 cnt++;
-            }
-
-            if (sendAmount < amount)
-            {
-                throw new BusinessException(
-                    $"The sum of total applicable outputs is less than the required: {amount.Satoshi} satoshis.",
-                    ErrorCode.NotEnoughFundsAvailable);
             }
 
             return cnt;


### PR DESCRIPTION
For now fee-rate based calculaction algorithm do not pay attention for Send and SendChange build steps (full tx fee calculated before these steps), but it have to.

this bug do not affect current state because mostly we have low fee (lower than min fee limit of full tx - mostly fees will be the same)